### PR TITLE
Addresses the issues in #214

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,6 +121,16 @@ services:
     entrypoint: ''
     command: bash
 
+  julia-runner:
+    image: codewars/julia-runner
+    volumes:
+      - ./lib:/runner/lib
+      - ./examples:/runner/examples
+      - ./frameworks:/runner/frameworks
+      - ./test:/runner/test
+    entrypoint: ''
+    command: bash
+
   # LANGUAGE SPECIFIC HELPERS
   javascript:
     image: codewars/node-runner

--- a/lib/runners/julia.js
+++ b/lib/runners/julia.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var shovel = require('../shovel'),
     config = require('../config'),
     codeWriteSync = require('../util').codeWriteSync,
@@ -17,11 +19,20 @@ module.exports.run = function run(opts, cb) {
             });
         },
         testIntegration: function (run) {
-            codeWriteSync('julia', opts.solution, juliaCodeDir);
+            codeWriteSync('julia', opts.code, juliaCodeDir, 'solution.jl', true);
+
             if (opts.setup) codeWriteSync('julia', opts.setup, juliaCodeDir);
+
+            let runCmd = `
+              include("frameworks/julia/Test.jl")
+              include("${juliaCodeDir}/solution.jl")
+              using Test
+              ${opts.fixture}
+            `
+
             run({
                 name: 'julia',
-                args: ['-P', ['push!(LOAD_PATH, "', juliaCodeDir , '", "frameworks/julia")'].join(""), '-e', opts.fixture]
+                args: ['-ie', runCmd]
             });
         }
     });

--- a/test/runners/julia_spec.js
+++ b/test/runners/julia_spec.js
@@ -1,48 +1,43 @@
 var expect = require('chai').expect;
 var runner = require('../runner');
 
-describe('julia runner', function () {
-    // These specs are compatible with both Julia 0.4.6
-        describe('.run', function () {
-            it('should handle basic code evaluation', function (done) {
-                runner.run({
-                    language: 'julia',
-                    code: 'print("42")'
-                }, function (buffer) {
-                    console.log(buffer);
-                    expect(buffer.stdout).to.equal('42');
-                    done();
-                });
-            }); 
-       });
-        describe('Test', function () {
-            it('should handle a basic assertion', function (done) {
-                    runner.run({
-                        language: 'julia', 
-                        code: 'a = 1', 
-                        fixture:'include("frameworks/julia/Test.jl")\nusing Test\nfacts(()->(@fact a => 1))',
-                        testFramework: 'Test'
-                    }, function (buffer) {
-                        expect(buffer.stdout).to.equal('("<PASSED::>Test Passed","<:LF:>\\n")');
-                        done();
-                    });
-                });
-
-                it('should handle a basic description', function (done) {
-                    runner.run({
-                        language: 'julia', 
-                        code: 'global a = 1', 
-                        fixture: 'include("frameworks/julia/Test.jl")\nusing Test\nfacts(()->(@fact  a => 1) ,"test")', 
-                        testFramework: 'Test'
-                    }, function (buffer) {
-                        expect(buffer.stdout).to.contain('<DESCRIBE::>test<:LF:>\n("<PASSED::>Test Passed","<:LF:>\\n")');
-                        done();
-                    });
-                });
-
+describe('julia runner', function() {
+  // These specs are compatible with both Julia 0.4.6
+  describe('.run', function() {
+      it('should handle basic code evaluation', function(done) {
+        runner.run({
+          language: 'julia',
+          code: 'print("42")'
+        }, function(buffer) {
+          expect(buffer.stdout).to.equal('42');
+          done();
         });
-});
- 
+      });
 
-  
-    
+    it('should handle a basic assertion', function(done) {
+      runner.run({
+        language: 'julia',
+        code: 'a = 1',
+        fixture: `
+          facts(()->(@fact a => 1))
+        `,
+        testFramework: 'Test'
+      }, function(buffer) {
+        expect(buffer.stdout).to.equal('("<PASSED::>Test Passed","<:LF:>\\n")');
+        done();
+      });
+    });
+
+    it('should handle a basic description', function(done) {
+      runner.run({
+        language: 'julia',
+        code: 'global a = 1',
+        fixture: 'facts(()->(@fact  a => 1) ,"test")',
+        testFramework: 'Test'
+      }, function(buffer) {
+        expect(buffer.stdout).to.contain('<DESCRIBE::>test<:LF:>\n("<PASSED::>Test Passed","<:LF:>\\n")');
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Hello,

Per your discussion in the pull request #214 I took a look there and found that, essentially the issue was that the include / using wasn't working out with the original logic to `push!(LOAD_PATH,"<loc>")` but maybe you will know more about whatever that was as best I could tell is it just wasn't picking up the file without the include.

I adjusted the code in the runner to:
- Just use the `-ie` arg against the full code snippet which includes the framework and solution etc
- Simplified the include to just add in the test frameworks so no one would have to include that in the site fixture block

Other changes:
- Added the entry for the docker-compose
- Just some formatting in the test spec file and snipped the includes as they are moved into the runner

**Notes:** The setup doesn't look like it will work now with that solution. The no-test solution just runs the solution directly in the term so I am doubting if the load path even works at all so you might want to consider how to do the setup instead, but if it was me id probably just jam it into the string like I did with the others in a sensible relevant place where it can be used by some users... I assume they are supposed to be able to include some kinds of standard modules? no ideas actually on Julia there but obviously one should be able to include logic and functions etc that are required by their kata.